### PR TITLE
10 delete one to many

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wigedev-fitness-log-server",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "API server for WFL",
   "main": "src/index.js",
   "scripts": {

--- a/src/v1/services/cycleService.ts
+++ b/src/v1/services/cycleService.ts
@@ -279,16 +279,20 @@ export class CycleService {
 
             // get workouts
             const cycleId = new ObjectId(req.params.id)
-            const workouts = await db.collection('workouts').find({ cycle_id: cycleId })
+            const workouts = await db
+                .collection('workouts')
+                .find({ cycle_id: cycleId })
 
             // delete sets in each workout
-            while(await workouts.hasNext()){
+            while (await workouts.hasNext()) {
                 const workout = await workouts.next()
-                await db.collection('sets').deleteMany({ workout_id: workout?._id})
+                await db
+                    .collection('sets')
+                    .deleteMany({ workout_id: workout?._id })
             }
 
             // delete all workouts
-            await db.collection('workouts').deleteMany({cycle_id: cycleId})
+            await db.collection('workouts').deleteMany({ cycle_id: cycleId })
 
             // delete the cycle
             const result = await db

--- a/src/v1/services/cycleService.ts
+++ b/src/v1/services/cycleService.ts
@@ -1,13 +1,14 @@
-import { Request, Response } from 'express'
-import { ObjectId, InsertOneResult, WithId, Document } from 'mongodb'
-import { Database } from '../../database/database'
 import {
     BadRequestError,
     InternalServerError,
     ServerMessage,
     UnauthorizedError,
 } from './responses'
+import { Document, InsertOneResult, ObjectId, WithId } from 'mongodb'
+import { Request, Response } from 'express'
 import { TokenPackage, TokenService } from './tokenService'
+
+import { Database } from '../../database/database'
 
 export class CycleService {
     private static _instance: CycleService
@@ -276,10 +277,23 @@ export class CycleService {
                 return
             }
 
+            // get workouts
+            const cycleId = new ObjectId(req.params.id)
+            const workouts = await db.collection('workouts').find({ cycle_id: cycleId })
+
+            // delete sets in each workout
+            while(await workouts.hasNext()){
+                const workout = await workouts.next()
+                await db.collection('sets').deleteMany({ workout_id: workout?._id})
+            }
+
+            // delete all workouts
+            await db.collection('workouts').deleteMany({cycle_id: cycleId})
+
             // delete the cycle
             const result = await db
                 .collection('cycles')
-                .deleteOne({ _id: new ObjectId(req.params.id) })
+                .deleteOne({ _id: cycleId })
 
             // check for results
             if (result?.deletedCount < 1) {

--- a/src/v1/services/exerciseService.ts
+++ b/src/v1/services/exerciseService.ts
@@ -254,7 +254,9 @@ export class ExerciseService {
 
             // delete sets
             const objId = new ObjectId(req.params?.id)
-            await Database.instance.db.collection('sets').deleteMany({ exercise_id: objId})
+            await Database.instance.db
+                .collection('sets')
+                .deleteMany({ exercise_id: objId })
 
             // delete the exercise
             const result = await Database.instance.db

--- a/src/v1/services/exerciseService.ts
+++ b/src/v1/services/exerciseService.ts
@@ -1,13 +1,14 @@
-import { Request, Response } from 'express'
-import { Db, InsertOneResult, ObjectId } from 'mongodb'
-import { Database } from '../../database/database'
 import {
     BadRequestError,
     InternalServerError,
     ServerMessage,
     UnauthorizedError,
 } from './responses'
+import { Db, InsertOneResult, ObjectId } from 'mongodb'
+import { Request, Response } from 'express'
 import { TokenPackage, TokenService } from './tokenService'
+
+import { Database } from '../../database/database'
 
 export class ExerciseService {
     private static _instance: ExerciseService
@@ -251,10 +252,14 @@ export class ExerciseService {
                 return
             }
 
+            // delete sets
+            const objId = new ObjectId(req.params?.id)
+            await Database.instance.db.collection('sets').deleteMany({ exercise_id: objId})
+
             // delete the exercise
             const result = await Database.instance.db
                 .collection('exercises')
-                .deleteOne({ _id: new ObjectId(req.params?.id) })
+                .deleteOne({ _id: objId })
             if (result?.deletedCount < 1)
                 throw Error('Failed to delete exercise')
         } catch {


### PR DESCRIPTION
# Description

Modified delete APIs for exercises and cycles so that they delete any objects that are associated via one-to-many relationships.

# Developer Checklist

- [x] NPM Audit
- [x] Update README
- [x] Style Fix
- [x] Lint Fix
- [x] Unit Tests