### PR TITLE
Set order

### DIFF
--- a/api-design.yml
+++ b/api-design.yml
@@ -766,16 +766,20 @@ paths:
                         type: integer
                       repsPrescribed:
                         type: integer
+                      order:
+                        type: integer
                     required:
                       - exerciseId
                       - weight
                       - unit
                       - repsPrescribed
+                      - order
                     example:
                       exerciseId: '1337'
                       weight: 135
                       unit: "lbs"
                       repsPrescribed: 10
+                      order: 0
       responses:
         '201': # Response
           description: OK
@@ -889,16 +893,20 @@ paths:
                         type: integer
                       repsPerformed:
                         type: integer
+                      order:
+                        type: integer
                     required:
                       - exerciseId
                       - weight
                       - unit
                       - repsPrescribed
+                      - order
                     example:
                       exerciseId: '1337'
                       weight: 135
                       unit: "lbs"
                       repsPrescribed: 10
+                      order: 0
       responses:
         '200': # Response
           description: OK

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wigedev-fitness-log-server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "API server for WFL",
   "main": "src/index.js",
   "scripts": {

--- a/src/v1/services/workoutService.spec.ts
+++ b/src/v1/services/workoutService.spec.ts
@@ -183,7 +183,8 @@ describe('WorkoutService', () => {
                 1,
                 'lbs' as Unit,
                 1,
-                1
+                1,
+                0
             ).then(() => {
                 // Assert
                 expect(spy).toHaveBeenCalled()

--- a/src/v1/services/workoutService.ts
+++ b/src/v1/services/workoutService.ts
@@ -171,7 +171,8 @@ export class WorkoutService {
                     set.weight,
                     set.unit,
                     set.repsPrescribed,
-                    set.repsPerformed
+                    set.repsPerformed,
+                    set.order
                 )
 
                 resultIds.push(setId)
@@ -347,7 +348,8 @@ export class WorkoutService {
                     set.weight,
                     set.unit,
                     set.repsPrescribed,
-                    set.repsPerformed
+                    set.repsPerformed,
+                    set.order
                 )
                 output.sets.push({
                     id: setId,
@@ -422,7 +424,8 @@ export class WorkoutService {
         weight: number,
         unit: Unit,
         repsPrescribed: number,
-        repsPerformed: number | null
+        repsPerformed: number | null,
+        order: number
     ): Promise<string> {
         const db = Database.instance.db
 
@@ -432,6 +435,7 @@ export class WorkoutService {
             weight: weight,
             unit: unit,
             repsPrescribed: repsPrescribed,
+            order: order
         }
 
         if (repsPerformed) {
@@ -460,6 +464,7 @@ interface SetReqBody {
     unit: Unit
     repsPrescribed: number
     repsPerformed: number | null
+    order: number
 }
 
 export enum Unit {

--- a/src/v1/services/workoutService.ts
+++ b/src/v1/services/workoutService.ts
@@ -435,7 +435,7 @@ export class WorkoutService {
             weight: weight,
             unit: unit,
             repsPrescribed: repsPrescribed,
-            order: order
+            order: order,
         }
 
         if (repsPerformed) {

--- a/src/v1/services/workoutService.ts
+++ b/src/v1/services/workoutService.ts
@@ -259,7 +259,7 @@ export class WorkoutService {
                 .collection('sets')
                 .aggregate([
                     { $match: { workout_id: workoutId } },
-                    { $sort: { exercise_id: 1, _id: 1 } },
+                    { $sort: { order: 1 } },
                 ])
 
             // build the sets array of the output object


### PR DESCRIPTION
# Description

POST & PUT /v1/workouts now saves set in order and GET /v1/workout/{date} now sorts them prior to returning the result

# Developer Checklist

- [x] NPM Audit
- [x] Unit Tests
- [x] Style Fix
- [x] Lint Fix
- [x] Update README
- [x] Bump Version